### PR TITLE
Ookami

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 */.vscode/*
 .vscode/
+*.o
+*.run

--- a/3/3/test
+++ b/3/3/test
@@ -1,1 +1,0 @@
-testowy plik do sprawdzenia czy doda się do mojego brancha

--- a/3/3/test
+++ b/3/3/test
@@ -1,0 +1,1 @@
+testowy plik do sprawdzenia czy doda się do mojego brancha

--- a/3/4/udpv6.cpp
+++ b/3/4/udpv6.cpp
@@ -4,7 +4,7 @@
  * Kompilacja:          clang++ -std=c++14 -o udpv6 udpv6.cpp -lpthread
  *                      Zamiast clang++ można użyć g++, ale nie jest to zalecane
  *                      Do skompilowaniu programu potrzebna jest biblioteka Boost.Asio oraz Boost.LexicalCast
- * Uruchamianie:        ./udpv6 <adres IP lub nazwa domenowa> <numer portu>
+ * Uruchamianie:        sudo ./udpv6 <adres IP lub nazwa domenowa> <numer portu>
  */
 
 #include <boost/asio/ip/udp.hpp>

--- a/3/5/ping.cpp
+++ b/3/5/ping.cpp
@@ -20,11 +20,6 @@
 #include <boost/asio/streambuf.hpp>
 #include <boost/asio/buffer.hpp>
 
-// #define SOURCE_PORT 12344
-// #define SOURCE_ADDRESS "2a02:a31a:a03d:7580:7c97:5950:50f0:b1f0"
-// należy zmienić interface na ten, którego się używa
-// #define INTERFACE "wlp2s0"
-
 
 namespace asio = boost::asio;
 using boost::system::error_code;
@@ -58,11 +53,9 @@ asio::io_context context;
 asio::ip::icmp::socket receiving_socket(context);
 
 
-// std::array<char, 256> buff;
+
 asio::streambuf buff(256);
 std::istream istr(&buff);
-// asio::streambuf::mutable_buffers_type buffs = buff.prepare(256);
-// std::ostream ostr(&buff);
 asio::ip::icmp::endpoint remote;
 
 /*
@@ -83,10 +76,8 @@ void async_receive_from_handler(const error_code &err, size_t bytes)
         return;
     }
 
-    // std::cout << "rcvfrom success" << std::flush << std::endl;
+    
     std::cout << "Pong received: ";
-    /* for(const auto& s: buff)
-        std::cout << s << ' '; */
 
     buff.commit(256);
     if(remote.address().is_v6())
@@ -103,12 +94,8 @@ void async_receive_from_handler(const error_code &err, size_t bytes)
     {
         header::ipv4 hipv4;
         
-        // buff.consume(256);
         
         istr >> hipv4;
-        // const struct iphdr hdr = hipv4.get();
-        // uint8_t test = hipv4.ttl();
-        // fprintf(stderr, "%u", test);
         std::cout << "v4 " << "hop limit:" << int(hipv4.ttl()) << " length:" << hipv4.length() << " destination address:" <<  header::address_to_string(hipv4.daddr()) << " ";
 
         
@@ -135,7 +122,7 @@ void async_receive_from_handler(const error_code &err, size_t bytes)
 .##.....##.##.....##.####.##....##
 */
 
-//TODO: Dopisać akceptowanie wracających pongów
+
 int main(int argc, char** argv) 
 {
     if (argc != 2 && argc != 3) 
@@ -146,21 +133,13 @@ int main(int argc, char** argv)
 
     header::icmp icmp_header;
 
-    /* asio::io_context context; */
+    
     error_code err;
     asio::ip::icmp::resolver resolver(context);
     asio::ip::icmp::endpoint endpoint;
 
     asio::ip::icmp::socket socket(context);
-    /* asio::ip::icmp::socket receiving_socket(context); */
-
     
-
-
-    
-    
-
-
 
     auto result = resolver.resolve(argv[1], nullptr, err);
     if(err)
@@ -170,7 +149,7 @@ int main(int argc, char** argv)
     }
 
     for(auto&& i : result)
-        /* if(i.endpoint().address().is_v6())  */endpoint = i.endpoint();
+        endpoint = i.endpoint();
 
     socket.open(endpoint.protocol());
 
@@ -200,18 +179,7 @@ int main(int argc, char** argv)
         receiving_socket.bind(asio::ip::icmp::endpoint(asio::ip::icmp::v4(), 0));
     }
 
-    /* std::array<char, 256> buff;
-    asio::ip::icmp::endpoint remote;
-    receiving_socket.async_receive_from(asio::buffer(buff), remote, [&](const error_code &err, size_t bytes)
-    {
-        if(err)
-        {
-            error("async_receive_from", err);
-            return;
-        }
-
-        receiving_socket.async_receive_from(asio::buffer(buff), remote, )
-    }); */
+    
     receiving_socket.async_receive_from(buff.prepare(256), remote, async_receive_from_handler);
 
     socket.connect(final_endpoint);
@@ -231,21 +199,13 @@ int main(int argc, char** argv)
         icmp_header.sequence(htons(i));
 
         std::string data = random_string(22);
-        // std::string data("");
 
         icmp_header.compute_checksum(data.data(), data.length());
-        // std::cerr << sizeof(data) << std::endl;
-
-
 
         asio::streambuf request_buffer;
         std::ostream os(&request_buffer);
 
-
-
         os << icmp_header << data;
-        
-
 
         socket.send(request_buffer.data(), 0, err);
         if(err)

--- a/3/5/ping.cpp
+++ b/3/5/ping.cpp
@@ -1,0 +1,146 @@
+/*
+ * Data:                2019-04-08
+ * Autor:               Jakub Markowski
+ * Kompilacja:          g++ ping.cpp -o ping.run -std=c++14 -lpthread
+ *                      Zamiast g++ można użyć clang++
+ *                      Do skompilowaniu programu potrzebna jest biblioteka Boost.Asio oraz Boost.LexicalCast
+ * Uruchamianie:        ./ping.run <adres IP lub nazwa domenowa>
+ */
+
+
+#include <boost/asio/generic/raw_protocol.hpp>
+#include <boost/lexical_cast.hpp>
+#include <iostream>
+#include <string>
+#include "../header/icmp.hpp"
+#include <boost/asio/ip/icmp.hpp>
+#include <boost/asio/ip/unicast.hpp>
+#include <boost/asio/streambuf.hpp>
+
+namespace asio = boost::asio;
+using boost::system::error_code;
+
+void error(const std::string& what, error_code err)
+{
+    if(err == asio::error::operation_aborted) return;
+
+    std::cerr << what << ": " << err.message() << std::endl;
+}
+
+//funkcja generująca losowe alfanumeryczne stringi
+//https://stackoverflow.com/questions/440133/how-do-i-create-a-random-alpha-numeric-string-in-c
+std::string random_string( size_t length )
+{
+    auto randchar = []() -> char
+    {
+        const char charset[] =
+        "0123456789"
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        "abcdefghijklmnopqrstuvwxyz";
+        const size_t max_index = (sizeof(charset) - 1);
+        return charset[ rand() % max_index ];
+    };
+    std::string str(length,0);
+    std::generate_n( str.begin(), length, randchar );
+    return str;
+}
+
+//TODO: Dopisać akceptowanie wracających pongów
+int main(int argc, char** argv) 
+{
+    if (argc != 2 && argc != 3) 
+    {
+        std::cerr << "Invocation: " << argv[0] << "<HOSTNAME OR IP ADDRESS> <INTERFACE>(optional for link-local addresses" << std::endl;
+        return 1;
+    }
+
+    header::icmp icmp_header;
+
+    asio::io_context context;
+    error_code err;
+    asio::ip::icmp::resolver resolver(context);
+    asio::ip::icmp::endpoint endpoint;
+
+    asio::ip::icmp::socket socket(context);
+
+    auto result = resolver.resolve(argv[1], nullptr, err);
+    if(err)
+    {
+        error("resolve", err);
+        return 1;
+    }
+
+    for(auto&& i : result)
+        /* if(i.endpoint().address().is_v6())  */endpoint = i.endpoint();
+
+    socket.open(endpoint.protocol());
+
+    asio::ip::unicast::hops ttl(64);
+    socket.set_option(ttl);
+
+    //TODO:Connect
+    asio::ip::icmp::endpoint final_endpoint;
+    if(endpoint.address().is_v6())
+    {
+        if(endpoint.address().to_v6().is_link_local())
+        {
+            final_endpoint = asio::ip::icmp::endpoint(asio::ip::make_address_v6(endpoint.address().to_v6().to_string()+"%"+argv[2]), boost::lexical_cast<unsigned short>(argv[2]));
+        }
+        else
+        {
+            final_endpoint = endpoint;
+        }
+        
+    }
+    else
+    {
+        final_endpoint = endpoint;
+    }
+
+    socket.connect(final_endpoint);
+    
+
+    //TODO: Poprawić send
+    for(int i = 1; i<5; i++)
+    {
+        header::icmp icmp_header;
+        icmp_header.type(8);
+        icmp_header.code(0);
+
+        uint32_t pid = getpid();
+        uint16_t lower_pid = (uint16_t) pid & 0x0000FFFF;
+
+        icmp_header.id(htons(lower_pid));
+        icmp_header.sequence(htons(i));
+
+        std::string data = random_string(22);
+        // std::string data("");
+
+        icmp_header.compute_checksum(data.data(), data.length());
+        // std::cerr << sizeof(data) << std::endl;
+
+
+
+        asio::streambuf request_buffer;
+        std::ostream os(&request_buffer);
+
+
+
+        os << icmp_header << data;
+        
+
+
+        socket.send(request_buffer.data(), 0, err);
+        if(err)
+        {
+            error("send_to", err);
+            return 1;
+        }
+        
+        sleep(1);
+    }
+
+    socket.close();
+
+    return 1;
+}

--- a/3/5/ping.cpp
+++ b/3/5/ping.cpp
@@ -71,6 +71,8 @@ asio::ip::icmp::endpoint remote;
 */
 int received_counter = 4;
 //TODO: sprawdzanie typu pakietu icmp
+/* Funkcja obsługująca odebrany pakiet icmp
+sprawdza typ odebranego pakietu, a następnie wypełnia struktury nagłówków i odczytuje z nich interesujące nas informacje. */
 void async_receive_from_handler(const error_code &err, size_t bytes)
 {
     if(err)
@@ -127,6 +129,8 @@ void timer_handler(const error_code &err);
 
 uint16_t sent_counter = 1;
 asio::deadline_timer tmr(context, boost::posix_time::seconds(1));
+/* Funkcja obsługująca wysłanie pakietu
+Uruchamia oczekiwanie 1 sek na wysłanie kolejnego */
 void async_send_handler(const error_code &err, const size_t sent)
 {
     if(sent_counter++<5)
@@ -146,6 +150,8 @@ void async_send_handler(const error_code &err, const size_t sent)
 uint16_t ping_type = 8;
 asio::ip::icmp::endpoint endpoint;
 asio::ip::icmp::socket sending_socket(context);
+/* Funkcja obsługująca zdarzenie minięcia sekundy
+Buduje pakiet icmp, a następnie wysyła go */
 void timer_handler(const error_code &err)
 {
 
@@ -199,7 +205,7 @@ int main(int argc, char** argv)
     asio::ip::icmp::resolver resolver(context);
     
     
-
+    // Rozwiązywanie nazwy
     auto result = resolver.resolve(argv[1], nullptr, err);
     if(err)
     {
@@ -212,11 +218,13 @@ int main(int argc, char** argv)
 
     sending_socket.open(endpoint.protocol());
 
+    // Ustawienie ttl
     asio::ip::unicast::hops ttl(64);
     sending_socket.set_option(ttl);
 
     
     asio::ip::icmp::endpoint final_endpoint;
+    /* Zbudowanie odpowiedniego adresu jeżeli jest link-local, oraz uruchomienie nasłuchiwania na odpowiednim protokole */
     if(endpoint.address().is_v6())
     {
         if(endpoint.address().to_v6().is_link_local())

--- a/3/5/ping.cpp
+++ b/3/5/ping.cpp
@@ -167,7 +167,7 @@ void timer_handler(const error_code &err)
 
     os << icmp_hdr << data;
 
-    // sending_socket.send(request_buffer.data(), 0, err);
+    
     tmr.expires_from_now(boost::posix_time::seconds(1));
     sending_socket.async_send(request_buffer.data(), async_send_handler);
 
@@ -243,7 +243,7 @@ int main(int argc, char** argv)
 
     sending_socket.connect(final_endpoint);
     
-    // header::icmp icmp_hdr;
+    
     icmp_hdr.type(ping_type);
     icmp_hdr.code(0);
     uint32_t pid = getpid();
@@ -261,42 +261,9 @@ int main(int argc, char** argv)
 
     os << icmp_hdr << data;
 
-    // sending_socket.send(request_buffer.data(), 0, err);
+    
     sending_socket.async_send(request_buffer.data(), async_send_handler);
     
-    /* for(int i = 1; i<5; i++)
-    {
-        header::icmp icmp_hdr;
-        icmp_hdr.type(ping_type);
-        icmp_hdr.code(0);
-
-        uint32_t pid = getpid();
-        uint16_t lower_pid = (uint16_t) pid & 0x0000FFFF;
-
-        icmp_hdr.id(htons(lower_pid));
-        icmp_hdr.sequence(htons(i));
-
-        std::string data = random_string(22);
-
-        icmp_hdr.compute_checksum(data.data(), data.length());
-
-        asio::streambuf request_buffer;
-        std::ostream os(&request_buffer);
-
-        os << icmp_hdr << data;
-
-        sending_socket.send(request_buffer.data(), 0, err);
-        if(err)
-        {
-            error("send_to", err);
-            return 1;
-        }
-        
-        
-    } */
-
-    
-
     context.run();
     sending_socket.close();
     receiving_socket.close();

--- a/3/5/ping.cpp
+++ b/3/5/ping.cpp
@@ -65,6 +65,16 @@ std::istream istr(&buff);
 // std::ostream ostr(&buff);
 asio::ip::icmp::endpoint remote;
 
+/*
+.##.....##....###....##....##.########..##.......########.########.
+.##.....##...##.##...###...##.##.....##.##.......##.......##.....##
+.##.....##..##...##..####..##.##.....##.##.......##.......##.....##
+.#########.##.....##.##.##.##.##.....##.##.......######...########.
+.##.....##.#########.##..####.##.....##.##.......##.......##...##..
+.##.....##.##.....##.##...###.##.....##.##.......##.......##....##.
+.##.....##.##.....##.##....##.########..########.########.##.....##
+*/
+
 void async_receive_from_handler(const error_code &err, size_t bytes)
 {
     if(err)
@@ -81,12 +91,12 @@ void async_receive_from_handler(const error_code &err, size_t bytes)
     buff.commit(256);
     if(remote.address().is_v6())
     {
-        header::ipv6 hipv6;
+        /* header::ipv6 hipv6;
         istr >> hipv6;
         in6_addr temp_daddr = hipv6.daddr();
         char daddr[INET6_ADDRSTRLEN];
         inet_ntop(AF_INET6, &temp_daddr, daddr, INET6_ADDRSTRLEN);
-        std::cout << "v6 " << "hop limit:" << hipv6.hlim() << " length:" << hipv6.length() << " destination address:" <<  daddr << " ";
+        std::cout << "v6 " << "hop limit:" << int(hipv6.hlim()) << " length:" << hipv6.length() << " destination address:" <<  daddr << " "; */
 
     }
     else
@@ -114,6 +124,16 @@ void async_receive_from_handler(const error_code &err, size_t bytes)
 
     receiving_socket.async_receive_from(buff.prepare(256), remote, async_receive_from_handler);
 }
+
+/*
+.##.....##....###....####.##....##
+.###...###...##.##....##..###...##
+.####.####..##...##...##..####..##
+.##.###.##.##.....##..##..##.##.##
+.##.....##.#########..##..##..####
+.##.....##.##.....##..##..##...###
+.##.....##.##.....##.####.##....##
+*/
 
 //TODO: Dopisać akceptowanie wracających pongów
 int main(int argc, char** argv) 
@@ -157,7 +177,7 @@ int main(int argc, char** argv)
     asio::ip::unicast::hops ttl(64);
     socket.set_option(ttl);
 
-    
+    uint16_t ping_type = 8;
     asio::ip::icmp::endpoint final_endpoint;
     if(endpoint.address().is_v6())
     {
@@ -171,6 +191,7 @@ int main(int argc, char** argv)
         }
         receiving_socket.open(asio::ip::icmp::v6());
         receiving_socket.bind(asio::ip::icmp::endpoint(asio::ip::icmp::v6(), 0));
+        ping_type += 120;
     }
     else
     {
@@ -200,7 +221,7 @@ int main(int argc, char** argv)
     for(int i = 1; i<5; i++)
     {
         header::icmp icmp_header;
-        icmp_header.type(8);
+        icmp_header.type(ping_type);
         icmp_header.code(0);
 
         uint32_t pid = getpid();

--- a/3/header/icmp.hpp
+++ b/3/header/icmp.hpp
@@ -40,7 +40,6 @@
 
 namespace header
 {
-//TODO : reszta pól nagłówka
     class icmp : public abstract 
     {
     public:

--- a/3/header/icmp.hpp
+++ b/3/header/icmp.hpp
@@ -64,6 +64,39 @@ namespace header
         void gateway(uint16_t gateway) { _header.un.gateway = gateway; }
 
         void compute_checksum() { check(checksum(reinterpret_cast<uint16_t*>(&_header), sizeof(icmphdr))); }
+        void compute_checksum(const void* data, size_t data_size)
+        {
+            unsigned short *buf = reinterpret_cast<uint16_t*>(&_header);
+            int bufsz = sizeof(icmphdr);
+            unsigned long sum = 0;
+            while( bufsz > 1 ) 
+            {
+                sum += *buf++;
+                bufsz -= 2;
+            }
+            if( bufsz == 1 ) sum += *(unsigned char *)buf;
+            // sum = (sum & 0xffff) + (sum >> 16);
+            // sum = (sum & 0xffff) + (sum >> 16);
+
+            // unsigned short *buf2 = reinterpret_cast<const uint16_t*>(data);
+            const uint16_t *buf2 = reinterpret_cast<const uint16_t*>(data);
+            int bufsz2 = data_size;
+            unsigned long sum2 = 0;
+            while( bufsz2 > 1 ) 
+            {
+                sum2 += *buf2++;
+                bufsz2 -= 2;
+            }
+            if( bufsz2 == 1 ) sum2 += *(unsigned char *)buf2;
+            // sum2 = (sum2 & 0xffff) + (sum2 >> 16);
+            // sum2 = (sum2 & 0xffff) + (sum2 >> 16);
+
+            sum += sum2;
+            sum = (sum & 0xffff) + (sum >> 16);
+            sum = (sum & 0xffff) + (sum >> 16);
+            
+            check(~sum);
+        }
 
         int length() const { return sizeof(_header); }
         char* get_header() { return reinterpret_cast<char*>(&_header); }

--- a/3/header/icmp.hpp
+++ b/3/header/icmp.hpp
@@ -49,7 +49,8 @@ namespace header
         icmp() : _header{0} {}
         explicit icmp(const header_type &icmph) : _header(icmph) {}
 
-        uint16_t type() const { return ntohs(_header.type); }
+        // uint16_t type() const { return ntohs(_header.type); }
+        uint16_t type() const { return _header.type; }
         uint16_t code() const { return ntohs(_header.code); }
         uint16_t check() const { return ntohs(_header.checksum); }
         uint16_t id() const { return ntohs(_header.un.echo.id); }


### PR DESCRIPTION
Jakbyś mógł zerknąć, może będziesz wiedział, dlaczego jak odbieram pakiet icmp ipv4 to mam nagłówek ip, a jak ipv6 to tego nagłówka nie ma (mam dlatego zaremowany fragment kodu który miał rozpakować nagłówek ip dla ipv6). Musiałem też w header::icmp dla type() wyrzucić ntohs (absolutnie nie mam pojęcia czemu tylko to jedno pole było odczytywane odwrotnie). Zerknij czy coś ci się jeszcze rzuca w oczy (poza dużą ilością zmiennych globalnych, już nie miałem czasu kombinować jak je poograniczać, tylko te które są wymagane przez handlery są globalne).